### PR TITLE
Fix crash bug on Notepad++ v7.9

### DIFF
--- a/HexEditor/src/misc/ModifyMenu.cpp
+++ b/HexEditor/src/misc/ModifyMenu.cpp
@@ -439,7 +439,7 @@ void GetShortCuts(HWND hWnd)
 		g_scList[i].isEnable = FALSE;
 		if (::GetMenuString(hMenu, g_scList[i].uID, text, 64, MF_BYCOMMAND) != 0)
 		{
-			pSc = &(_tcsstr(text, _T("\t")))[1];
+			pSc = _tcsstr(text, _T("\t"));
 			if (pSc != NULL) {
 				g_scList[i].isEnable = TRUE;
 				pScKey = _tcsstr(pSc, _T("Ctrl+"));


### PR DESCRIPTION
In Notepad++ v7.9, the shorcut of command IDM_EDIT_INS_TAB has been removed, whereas the function GetShortCuts() expected a shortcut from this command. This fix makes it work on 2 cases (with or without shorcut).

Fix #36