### PR TITLE
Fix: Fonts are now drawn in default mode.

### DIFF
--- a/HexEditor/src/HEXDialog.h
+++ b/HexEditor/src/HEXDialog.h
@@ -438,7 +438,7 @@ private:
 		if (hDc != NULL) {
 			_hFont = ::CreateFont(-MulDiv(g_iFontSize[_fontSize], GetDeviceCaps(hDc, LOGPIXELSY), 72) - zoomFactor, 0, 0, 0,
 				(isFontBold() == TRUE) ? FW_BOLD : FW_NORMAL, isFontItalic(), isFontUnderline(),
-				0, ANSI_CHARSET, OUT_TT_ONLY_PRECIS, 0, ANTIALIASED_QUALITY, FIXED_PITCH | FF_MODERN, getFontName());
+				0, ANSI_CHARSET, OUT_TT_ONLY_PRECIS, 0, DEFAULT_QUALITY, FIXED_PITCH | FF_MODERN, getFontName());
 			if (_hFont)
 			{
 				::SendMessage(_hListCtrl, WM_SETFONT, reinterpret_cast<WPARAM>(_hFont), 0);


### PR DESCRIPTION
According to [Qs on CLEARTYPE_QUALITY][1] and [CreateFontA function][2], I restored drawn method to default mode, so font display will depend on settings of the os . Hope this will help.

[1]:https://microsoft.public.win32.programmer.gdi.narkive.com/aN0sKX1g/qs-on-cleartype-quality
[2]:https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createfonta