### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_MS_analysis.yml
+++ b/.github/workflows/CI_MS_analysis.yml
@@ -2,6 +2,9 @@ name: CI_MS_analysis
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 4'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/chcg/NPP_HexEditor/security/code-scanning/21](https://github.com/chcg/NPP_HexEditor/security/code-scanning/21)

Add an explicit `permissions` block at the workflow root in `.github/workflows/CI_MS_analysis.yml`, directly under `on:` (or before `jobs:`), so all jobs inherit least-privilege defaults.  
For this workflow, the best minimal permission is:

- `contents: read`

This is sufficient for checkout and build operations shown, and avoids granting implicit write scopes.

No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
