### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 4'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/chcg/NPP_HexEditor/security/code-scanning/20](https://github.com/chcg/NPP_HexEditor/security/code-scanning/20)

Add an explicit `permissions` block to the workflow so the token scope is clearly restricted and stable regardless of repository/org defaults.  
Best fix here: add workflow-level permissions directly under `on` (before `jobs`) with the minimum needed for CodeQL:

- `contents: read` (read repository content)
- `security-events: write` (required for uploading CodeQL SARIF results)

This preserves functionality while enforcing least privilege for all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
