### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -2,6 +2,9 @@ name: CI_build
 
 on: [push, pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/chcg/NPP_HexEditor/security/code-scanning/19](https://github.com/chcg/NPP_HexEditor/security/code-scanning/19)

Add an explicit `permissions` block in `.github/workflows/CI_build.yml` at the workflow root (right after `on:`), so it applies to all jobs unless overridden.  
Given this workflow checks out code, reads tags, uploads artifacts, and creates releases, the minimal safe explicit set is:

- `contents: write` (needed for creating GitHub releases)
- all unspecified scopes default to `none` automatically

This preserves functionality (release creation on tags) while removing ambiguity from inherited defaults. No imports/methods/dependencies are needed; only YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
